### PR TITLE
external/avb: Add rollback only support for info_image

### DIFF
--- a/avbtool.py
+++ b/avbtool.py
@@ -2405,16 +2405,16 @@ class Avb(object):
     misc_image.seek(self.AB_MISC_METADATA_OFFSET)
     misc_image.write(ab_data)
 
-  def info_image(self, image_filename, output, atx):
+  def info_image(self, args):
     """Implements the 'info_image' command.
 
     Arguments:
-      image_filename: Image file to get information from (file object).
-      output: Output file to write human-readable information to (file object).
-      atx: If True, show information about Android Things eXtension (ATX).
+      args.image.name: Image file to get information from (file object).
+      args.output: Output file to write human-readable information to (file object).
+      args.atx: If True, show information about Android Things eXtension (ATX).
     """
-    image = ImageHandler(image_filename, read_only=True)
-    o = output
+    image = ImageHandler(args.image.name, read_only=True)
+    o = args.output
     (footer, header, descriptors, image_size) = self._parse_image(image)
 
     # To show the SHA1 of the public key.
@@ -2464,7 +2464,7 @@ class Avb(object):
     if num_printed == 0:
       o.write('    (none)\n')
 
-    if atx and header.public_key_metadata_size:
+    if args.atx and header.public_key_metadata_size:
       o.write('Android Things eXtension (ATX):\n')
       key_metadata_offset = (header.SIZE +
                              header.authentication_data_block_size +
@@ -4868,7 +4868,7 @@ class AvbTool(object):
 
   def info_image(self, args):
     """Implements the 'info_image' sub-command."""
-    self.avb.info_image(args.image.name, args.output, args.atx)
+    self.avb.info_image(args)
 
   def verify_image(self, args):
     """Implements the 'verify_image' sub-command."""

--- a/avbtool.py
+++ b/avbtool.py
@@ -2424,6 +2424,12 @@ class Avb(object):
                   header.public_key_offset)
     key_blob = vbmeta_blob[key_offset:key_offset + header.public_key_size]
 
+    if args.rollback_index_location:
+      o.write('{}\n'.format(header.rollback_index_location))
+      return
+    if args.rollback_index:
+      o.write('{}\n'.format(header.rollback_index))
+      return
     if footer:
       o.write('Footer version:           {}.{}\n'.format(footer.version_major,
                                                          footer.version_minor))
@@ -4529,6 +4535,12 @@ class AvbTool(object):
     sub_parser.add_argument('--atx',
                             help=('Show information about Android Things '
                                   'eXtension (ATX).'),
+                            action='store_true')
+    sub_parser.add_argument('--rollback_index',
+                            help=('Only rollback_index'),
+                            action='store_true')
+    sub_parser.add_argument('--rollback_index_location',
+                            help=('Only rollback_index_location'),
                             action='store_true')
     sub_parser.set_defaults(func=self.info_image)
 


### PR DESCRIPTION
## Summary
1. external/avb: Passing all sub arguments to info_image
2. external/avb: Add rollback only support for info_image

## Impact
avb_verify

## Testing
1. Selftest
```bash
# test.bin
#  rollback_index_location : 0
#  rollback_index          : 1
$ ./avbtool info_image --image test.bin --rollback_index
1
$ ./avbtool info_image --image test.bin --rollback_index_location
0
```
2. CI

